### PR TITLE
Review and merge pull request changes

### DIFF
--- a/.mcp.json
+++ b/.mcp.json
@@ -1,15 +1,10 @@
 {
   "mcpServers": {
     "playwright": {
-      "command": "npx",
+      "command": "bash",
       "args": [
-        "@playwright/mcp@latest",
-        "--config",
-        ".mcp/playwright-firefox-config.json",
-        "--browser",
-        "firefox",
-        "--proxy-server",
-        "$HTTPS_PROXY"
+        "-c",
+        "npx @playwright/mcp@latest --config .mcp/playwright-firefox-config.json --browser firefox --proxy-server=\"$HTTPS_PROXY\""
       ],
       "env": {
         "HOME": "/home/user/Kagami/.mcp/firefox_home"


### PR DESCRIPTION
Problem:
- Original config used "--proxy-server" and "$HTTPS_PROXY" as separate args
- Environment variable was not being expanded correctly
- This caused NS_ERROR_UNKNOWN_PROXY_HOST error

Solution:
- Changed command from "npx" to "bash -c"
- Combined all args into single shell command string
- Shell now properly expands $HTTPS_PROXY at runtime
- This allows dynamic proxy URLs with JWT tokens to work correctly

This fixes the proxy configuration issue identified in PR #16 review.