### PR TITLE
Playwright tools and features overview

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -16,5 +16,6 @@
         ]
       }
     ]
-  }
+  },
+  "enabledMcpjsonServers": ["playwright"]
 }

--- a/mcp.json
+++ b/mcp.json
@@ -1,0 +1,15 @@
+{
+  "mcpServers": {
+    "playwright": {
+      "command": "uv",
+      "args": [
+        "run",
+        "python",
+        "playwright_mcp_claude_code_web/mcp.py"
+      ],
+      "env": {
+        "HOME": "/home/user"
+      }
+    }
+  }
+}


### PR DESCRIPTION
mcp.jsonとsettings.jsonを設定し、次回セッションから
mcp__playwright__*ツールが利用可能になるようにした。

- mcp.json: playwright MCPサーバーの定義を追加
  - mcp.pyがproxy.pyを自動起動・停止
- .claude/settings.json: enabledMcpjsonServersでplaywrightを有効化